### PR TITLE
Потдержка java modules

### DIFF
--- a/src/main/java/com/github/demidko/aot/bytecode/BytecodeUtils.java
+++ b/src/main/java/com/github/demidko/aot/bytecode/BytecodeUtils.java
@@ -1,10 +1,10 @@
-package com.github.demidko.aot;
+package com.github.demidko.aot.bytecode;
 
-final class BytecodeUtils {
+public final class BytecodeUtils {
 
   private static final byte endOfCompiledLine = 100;
 
-   static char safeByteToChar(byte b) {
+  public static char safeByteToChar(byte b) {
     char c = byteToChar(b);
     if (c == 0) {
       throw new IllegalArgumentException("Invalid byte character: " + b);
@@ -12,7 +12,7 @@ final class BytecodeUtils {
     return c;
   }
 
-  static char byteToChar(byte b) {
+  public static char byteToChar(byte b) {
     switch (b) {
       case (byte) 0x2d:
         return '-';
@@ -178,7 +178,7 @@ final class BytecodeUtils {
     }
   }
 
-  static byte safeCharToByte(char n) {
+  public static byte safeCharToByte(char n) {
     byte b = charToByte(n);
     if (b == 0) {
       throw new IllegalArgumentException("Invalid character: " + n);
@@ -186,7 +186,7 @@ final class BytecodeUtils {
     return b;
   }
 
-  static byte charToByte(char n) {
+  public static byte charToByte(char n) {
     switch (n) {
       case '-':
         return (byte) 0x2d;
@@ -350,11 +350,11 @@ final class BytecodeUtils {
     }
   }
 
-  static boolean isEndOfLine(byte b) {
+  public static boolean isEndOfLine(byte b) {
     return b == endOfCompiledLine;
   }
 
-  static boolean isContent(byte b) {
+  public static boolean isContent(byte b) {
     return b != endOfCompiledLine;
   }
 }

--- a/src/main/java/com/github/demidko/aot/morphology/MorphologyTag.java
+++ b/src/main/java/com/github/demidko/aot/morphology/MorphologyTag.java
@@ -1,4 +1,4 @@
-package com.github.demidko.aot;
+package com.github.demidko.aot.morphology;
 
 /**
  * Морфологическая характеристика для слова. Например {@link MorphologyTag#FirstPerson}


### PR DESCRIPTION
[issue-9](https://github.com/demidko/aot/issues/9)
Изменил пакеты:
1) `BytecodeUtils com.github.demidko.aot -> com.github.demidko.aot.bytecode`
2) `MorphologyTag com.github.demidko.aot -> com.github.demidko.aot.morphology`

добавил модификатор public в BytecodeUtils 


Показалось, что для `MorphologyTag `не совсем подходит паке `.bytecode`, поэтому вынес в отдельный пакет.
В `BytecodeUtils `пришлось уйти от `package-private`, так как он используется в других пакетах (в других репозиториях).

`module-info.java` не стал добавлять, чтобы не усложнять проект Multi-Release JAR, в gradle его можно генерить в библиотеках на стороне потребителя.

Для базовой поддержки модульности этих изменений должно хватить (вместе с адаптацией под них `aot`, после сборки новой версии `aot-bytecode`).